### PR TITLE
Fix issue #1, RibbonToolTip definition was adjusted.

### DIFF
--- a/Odyssey/Odyssey/Themes/Ribbon/RibbonToolTip.xaml
+++ b/Odyssey/Odyssey/Themes/Ribbon/RibbonToolTip.xaml
@@ -12,13 +12,13 @@
             <Border BorderBrush="Gray" BorderThickness="1" CornerRadius="3" Background="{TemplateBinding Background}">
                 <Grid Margin="4">
                     <Grid.RowDefinitions>
+                        <RowDefinition Height="Auto"/>
                         <RowDefinition />
-                        <RowDefinition />
-                        <RowDefinition />
-                        <RowDefinition />
+                        <RowDefinition Height="Auto"/>
+                        <RowDefinition Height="Auto"/>
                     </Grid.RowDefinitions>
                     <Grid.ColumnDefinitions>
-                        <ColumnDefinition />
+                        <ColumnDefinition Width="Auto"/>
                         <ColumnDefinition />
                     </Grid.ColumnDefinitions>
                     <TextBlock Grid.ColumnSpan="2" Text="{TemplateBinding Title}" FontWeight="Bold" Margin="0,0,0,4" />


### PR DESCRIPTION
Column and row definitions were adjusted to hide itself when all content is collapsed.